### PR TITLE
Properly propagate showTemperature/Humidity

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -313,6 +313,14 @@ export class BigAssFans_i6PlatformAccessory {
       this.enableDebugPort = true;
     }
 
+    if (accessory.context.device.showTemperature !== undefined) {
+        this.showTemperature = accessory.context.device.showTemperature;
+    }
+
+    if (accessory.context.device.showHumidity !== undefined) {
+        this.showHumidity = accessory.context.device.showHumidity;
+    }
+
     /**
     * set accessory information
     */

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -329,11 +329,11 @@ export class BigAssFans_i6PlatformAccessory {
     }
 
     if (accessory.context.device.showTemperature !== undefined) {
-        this.showTemperature = accessory.context.device.showTemperature;
+      this.showTemperature = accessory.context.device.showTemperature;
     }
 
     if (accessory.context.device.showHumidity !== undefined) {
-        this.showHumidity = accessory.context.device.showHumidity;
+      this.showHumidity = accessory.context.device.showHumidity;
     }
 
     /**


### PR DESCRIPTION
These settings were not properly propagated, so settings them to false (when they default to true) did nothing. See issue #38.